### PR TITLE
Add Gameworld MVP, analytics, and smoke test

### DIFF
--- a/llm_social_simulation/simulation/analytics.py
+++ b/llm_social_simulation/simulation/analytics.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def cooperation_rate_per_round(history) -> List[float]:
+    """
+    Compute cooperation rate per round.
+
+    We treat each directed action i->j as one decision.
+    cooperation_rate = (# of "C") / (total actions) for that round.
+    """
+    rates: List[float] = []
+    for tick in history:
+        total = 0
+        coop = 0
+        for _, per_neighbor in tick.actions.items():
+            for a in per_neighbor.values():
+                total += 1
+                if a == "C":
+                    coop += 1
+        rates.append(coop / total if total else 0.0)
+    return rates
+
+
+def final_wealth(history) -> Dict[int, int]:
+    """Convenience helper: wealth snapshot from the last tick."""
+    if not history:
+        return {}
+    return dict(history[-1].wealth)

--- a/llm_social_simulation/simulation/gameworld.py
+++ b/llm_social_simulation/simulation/gameworld.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple, Any
+import copy
+
+Action = str  # "C" or "D"
+
+
+@dataclass(frozen=True)
+class PayoffMatrix:
+    """
+    Prisoner's Dilemma payoff:
+    - (C, C) -> (R, R)
+    - (D, D) -> (P, P)
+    - (D, C) -> (T, S)
+    - (C, D) -> (S, T)
+    Must satisfy: T > R > P > S
+    """
+
+    T: int = 5
+    R: int = 3
+    P: int = 1
+    S: int = 0
+
+    def payoff(self, a_i: Action, a_j: Action) -> Tuple[int, int]:
+        if a_i == "C" and a_j == "C":
+            return self.R, self.R
+        if a_i == "D" and a_j == "D":
+            return self.P, self.P
+        if a_i == "D" and a_j == "C":
+            return self.T, self.S
+        if a_i == "C" and a_j == "D":
+            return self.S, self.T
+        raise ValueError(f"Invalid actions: {a_i}, {a_j}")
+
+
+@dataclass
+class TickResult:
+    round: int
+    actions: Dict[int, Dict[int, Action]]  # i -> (neighbor -> action)
+    delta_payoff: Dict[int, int]  # i -> payoff gained this round
+    wealth: Dict[int, int]  # snapshot after update
+
+
+class Gameworld:
+    """
+    Single source of truth:
+    - graph: adjacency list (undirected)
+    - wealth: cumulative payoff per agent
+    - last_actions: directed record of last round actions (i, j) -> action i took to j
+    - t: current round index
+    """
+
+    def __init__(self, graph: Dict[int, List[int]], payoff: PayoffMatrix | None = None):
+        self.graph = graph
+        self.payoff = payoff or PayoffMatrix()
+        self.wealth: Dict[int, int] = {i: 0 for i in graph.keys()}
+        self.last_actions: Dict[Tuple[int, int], Action] = {}
+        self.t: int = 0
+
+    def neighbors(self, i: int) -> List[int]:
+        return self.graph[i]
+
+    def get_observation(self, i: int) -> Dict[str, Any]:
+        """
+        Observation should be local + minimal.
+        For MVP: only include what neighbors did to me last round, my wealth, round.
+        """
+        neis = self.neighbors(i)
+        last_from_neighbors = {j: self.last_actions.get((j, i), "C") for j in neis}
+
+        return {
+            "self_id": i,
+            "neighbors": neis,
+            "last_actions_from_neighbors": last_from_neighbors,
+            "self_wealth": self.wealth[i],
+            "round": self.t,
+        }
+
+    def apply_actions(self, actions: Dict[int, Dict[int, Action]]) -> TickResult:
+        """
+        actions[i][j] is the action agent i takes toward neighbor j in this round.
+
+        We compute payoff on each undirected edge once (i < j) to avoid double counting.
+        """
+
+        # --- validate ---
+        for i in self.graph.keys():
+            if i not in actions:
+                raise ValueError(f"Missing actions for agent {i}")
+            for j in self.neighbors(i):
+                if j not in actions[i]:
+                    raise ValueError(f"Agent {i} missing action toward neighbor {j}")
+                if actions[i][j] not in ("C", "D"):
+                    raise ValueError(f"Invalid action {actions[i][j]} from {i} to {j}")
+
+        delta = {i: 0 for i in self.graph.keys()}
+
+        # --- payoff update (undirected edges counted once) ---
+        for i in self.graph.keys():
+            for j in self.neighbors(i):
+                if i < j:
+                    a_ij = actions[i][j]
+                    a_ji = actions[j][i]
+                    pi, pj = self.payoff.payoff(a_ij, a_ji)
+                    delta[i] += pi
+                    delta[j] += pj
+
+        # --- update wealth ---
+        for i in self.graph.keys():
+            self.wealth[i] += delta[i]
+
+        # --- update last_actions for next round (directed store) ---
+        new_last: Dict[Tuple[int, int], Action] = {}
+        for i in self.graph.keys():
+            for j in self.neighbors(i):
+                new_last[(i, j)] = actions[i][j]
+        self.last_actions = new_last
+
+        tick = TickResult(
+            round=self.t,
+            actions=copy.deepcopy(actions),
+            delta_payoff=delta,
+            wealth=copy.deepcopy(self.wealth),
+        )
+        self.t += 1
+        return tick

--- a/llm_social_simulation/simulation/test_gameworld_smoke.py
+++ b/llm_social_simulation/simulation/test_gameworld_smoke.py
@@ -1,0 +1,72 @@
+from llm_social_simulation.simulation.engine import SimulationEngine
+from llm_social_simulation.simulation.gameworld import Gameworld, PayoffMatrix
+from llm_social_simulation.simulation.analytics import cooperation_rate_per_round
+
+
+class AlwaysC:
+    def __init__(self, agent_id: int):
+        self.agent_id = agent_id
+
+    def decide(self, obs):
+        return {j: "C" for j in obs["neighbors"]}
+
+
+class AlwaysD:
+    def __init__(self, agent_id: int):
+        self.agent_id = agent_id
+
+    def decide(self, obs):
+        return {j: "D" for j in obs["neighbors"]}
+
+
+def make_ring_graph(n: int, k_each_side: int = 1):
+    g = {i: set() for i in range(n)}
+    for i in range(n):
+        for d in range(1, k_each_side + 1):
+            g[i].add((i + d) % n)
+            g[i].add((i - d) % n)
+    return {i: sorted(neis) for i, neis in g.items()}
+
+
+def main():
+    n = 10
+    graph = make_ring_graph(n=n, k_each_side=1)
+    payoff = PayoffMatrix(T=5, R=3, P=1, S=0)
+
+    gw = Gameworld(graph=graph, payoff=payoff)
+    agents = [AlwaysC(i) if i < 5 else AlwaysD(i) for i in range(n)]
+
+    engine = SimulationEngine(gameworld=gw, agents=agents)
+    history = engine.run(rounds=10)
+
+    print("OK: ran 10 rounds")
+    print("Final wealth:", history[-1].wealth)
+    print("Round 0 delta:", history[0].delta_payoff)
+    print("Round 0 actions for agent 0:", history[0].actions[0])
+
+    rates = cooperation_rate_per_round(history)
+    print("Cooperation rate per round:", rates)
+
+
+def test_smoke_runs_and_updates_wealth():
+    n = 10
+    graph = make_ring_graph(n=n, k_each_side=1)
+    payoff = PayoffMatrix(T=5, R=3, P=1, S=0)
+
+    gw = Gameworld(graph=graph, payoff=payoff)
+    agents = [AlwaysC(i) if i < 5 else AlwaysD(i) for i in range(n)]
+
+    engine = SimulationEngine(gameworld=gw, agents=agents)
+    history = engine.run(rounds=5)
+
+    assert len(history) == 5
+    assert any(v != 0 for v in history[-1].wealth.values())
+
+    # optional: sanity check analytics runs and returns correct length
+    rates = cooperation_rate_per_round(history)
+    assert len(rates) == 5
+    assert all(0.0 <= r <= 1.0 for r in rates)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a minimal Gameworld implementation with Prisoner’s Dilemma payoff logic, basic analytics, and an end-to-end smoke test validated via pytest.