### PR TITLE
Stabilize LLM Open Resources pipeline: schema compatibility, richer diagnostics, and guardrails observability

### DIFF
--- a/llm_social_simulation/models/memory.py
+++ b/llm_social_simulation/models/memory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -17,7 +18,7 @@ class MemoryEvent:
 
     def to_prompt_item(
         self,
-    ) -> dict[str, float | int | bool | str | dict[str, float] | dict[str, bool] | None]:
+    ) -> dict[str, Any]:
         return {
             "t": self.t,
             "R": self.R,

--- a/llm_social_simulation/models/openrouter_client.py
+++ b/llm_social_simulation/models/openrouter_client.py
@@ -7,7 +7,10 @@ from typing import Any
 from urllib import error
 from urllib import request as urlrequest
 
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - optional dependency in some test envs
+    load_dotenv = None
 
 from .client import LLMClient
 from .types import (
@@ -20,7 +23,8 @@ from .types import (
     LLMUsage,
 )
 
-load_dotenv()
+if load_dotenv is not None:
+    load_dotenv()
 
 
 class OpenRouterClient(LLMClient):

--- a/llm_social_simulation/models/parser.py
+++ b/llm_social_simulation/models/parser.py
@@ -18,7 +18,8 @@ class OpenResourcesActionPayload(BaseModel):
 
 class OpenResourcesDecisionPayload(BaseModel):
     required: Literal[True]
-    self_id: int
+    self_id: int | None = None
+    agent_id: int | None = None
     t: int
     action: OpenResourcesActionPayload
     reason: str | None = None
@@ -28,6 +29,8 @@ class OpenResourcesDecisionPayload(BaseModel):
 class ParsedOpenResourcesDecision:
     action: OpenResourcesAction
     reason: str | None
+    id_filled: bool = False
+    id_source: Literal["self_id", "agent_id", "fallback"] = "self_id"
 
 
 def open_resources_response_format() -> dict[str, object]:
@@ -45,9 +48,23 @@ def parse_open_resources_decision(
     payload = strict_json_parse(content, OpenResourcesDecisionPayload)
 
     # --- enforce round/agent consistency with current observation ---
-    if payload.self_id != expected_agent_id:
+    id_filled = False
+    id_source: Literal["self_id", "agent_id", "fallback"] = "self_id"
+    if payload.self_id is not None:
+        self_id = payload.self_id
+        id_source = "self_id"
+    elif payload.agent_id is not None:
+        self_id = payload.agent_id
+        id_source = "agent_id"
+    else:
+        self_id = expected_agent_id
+        id_filled = True
+        id_source = "fallback"
+
+    # tolerate missing id from model; fill with known agent_id
+    if self_id != expected_agent_id:
         raise LLMParseError(
-            f"Response self_id mismatch: expected {expected_agent_id}, got {payload.self_id}"
+            f"Response self_id mismatch: expected {expected_agent_id}, got {self_id}"
         )
     if payload.t != expected_t:
         raise LLMParseError(f"Response t mismatch: expected {expected_t}, got {payload.t}")
@@ -59,4 +76,6 @@ def parse_open_resources_decision(
             contribute=float(payload.action.contribute),
         ),
         reason=payload.reason,
+        id_filled=id_filled,
+        id_source=id_source,
     )

--- a/llm_social_simulation/models/parser.py
+++ b/llm_social_simulation/models/parser.py
@@ -17,7 +17,7 @@ class OpenResourcesActionPayload(BaseModel):
 
 
 class OpenResourcesDecisionPayload(BaseModel):
-    required: Literal[True]
+    required: bool | None = None
     self_id: int | None = None
     agent_id: int | None = None
     t: int
@@ -48,6 +48,9 @@ def parse_open_resources_decision(
     payload = strict_json_parse(content, OpenResourcesDecisionPayload)
 
     # --- enforce round/agent consistency with current observation ---
+    if payload.required is False:
+        raise LLMParseError("Response required field must not be false")
+
     id_filled = False
     id_source: Literal["self_id", "agent_id", "fallback"] = "self_id"
     if payload.self_id is not None:

--- a/llm_social_simulation/models/policies/__init__.py
+++ b/llm_social_simulation/models/policies/__init__.py
@@ -4,9 +4,6 @@ from .llm_open_resources import LLMOpenResourcesPolicy, LLMOpenResourcesPolicyCo
 
 __all__ = [
     "GuardrailsPolicy",
-from .llm_open_resources import LLMOpenResourcesPolicy, LLMOpenResourcesPolicyConfig
-
-__all__ = [
     "LLMOpenResourcesPolicy",
     "LLMOpenResourcesPolicyConfig",
     "OpenResourcesPolicy",

--- a/llm_social_simulation/models/policies/guardrails.py
+++ b/llm_social_simulation/models/policies/guardrails.py
@@ -18,17 +18,29 @@ class GuardrailsPolicy(OpenResourcesPolicy):
     max_harvest_per_step: float
     sustainable_frac: float = 0.4
     contrib_max_frac: float = 0.2
+    fail_closed_count: int = 0
+    harvest_nan_count: int = 0
+    contribute_nan_count: int = 0
+    harvest_clamp_count: int = 0
+    contribute_clamp_count: int = 0
+    last_error: str | None = None
 
     def decide(self, obs: OpenResourcesObservation) -> OpenResourcesAction:
         try:
             act = self.inner.decide(obs)
-        except Exception:
+        except Exception as exc:
+            self.fail_closed_count += 1
+            self.last_error = f"{type(exc).__name__}: {exc}"
             return OpenResourcesAction(harvest=0.0, contribute=0.0)
 
         harvest = float(act.harvest)
         if harvest != harvest:
+            self.harvest_nan_count += 1
             harvest = 0.0
+        before_clamp_harvest = harvest
         harvest = max(0.0, min(harvest, float(self.max_harvest_per_step)))
+        if harvest != before_clamp_harvest:
+            self.harvest_clamp_count += 1
 
         n = 1
         try:
@@ -36,12 +48,19 @@ class GuardrailsPolicy(OpenResourcesPolicy):
         except Exception:
             n = 1
         sustainable_cap = float(self.sustainable_frac) * float(obs.R) / n
+        before_sustainable_cap = harvest
         harvest = min(harvest, sustainable_cap)
+        if harvest != before_sustainable_cap:
+            self.harvest_clamp_count += 1
 
         contribute = float(act.contribute)
         if contribute != contribute:
+            self.contribute_nan_count += 1
             contribute = 0.0
+        before_clamp_contrib = contribute
         contribute = max(0.0, contribute)
         contribute = min(contribute, float(self.contrib_max_frac) * float(obs.self_wealth))
+        if contribute != before_clamp_contrib:
+            self.contribute_clamp_count += 1
 
         return OpenResourcesAction(harvest=harvest, contribute=contribute)

--- a/llm_social_simulation/models/policies/guardrails.py
+++ b/llm_social_simulation/models/policies/guardrails.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 from llm_social_simulation.simulation.gameworld import OpenResourcesAction, OpenResourcesObservation
 
@@ -24,6 +25,8 @@ class GuardrailsPolicy(OpenResourcesPolicy):
     harvest_clamp_count: int = 0
     contribute_clamp_count: int = 0
     last_error: str | None = None
+    contribute_clamp_reason_counts: dict[str, int] = field(default_factory=dict)
+    contribute_clamp_events: list[dict[str, Any]] = field(default_factory=list)
 
     def decide(self, obs: OpenResourcesObservation) -> OpenResourcesAction:
         try:
@@ -54,13 +57,44 @@ class GuardrailsPolicy(OpenResourcesPolicy):
             self.harvest_clamp_count += 1
 
         contribute = float(act.contribute)
+        raw_contribute = contribute
+        clamp_reasons: list[str] = []
+        wealth = float(obs.self_wealth)
+        max_contribute = float(self.contrib_max_frac) * wealth
+
         if contribute != contribute:
             self.contribute_nan_count += 1
             contribute = 0.0
-        before_clamp_contrib = contribute
-        contribute = max(0.0, contribute)
-        contribute = min(contribute, float(self.contrib_max_frac) * float(obs.self_wealth))
-        if contribute != before_clamp_contrib:
+            clamp_reasons.append("nan")
+        if contribute < 0.0:
+            clamp_reasons.append("negative")
+            contribute = 0.0
+        if contribute > max_contribute:
+            clamp_reasons.append("above_max_contribute")
+            contribute = max_contribute
+
+        if contribute != raw_contribute:
             self.contribute_clamp_count += 1
+            if not clamp_reasons:
+                clamp_reasons.append("other")
+            for reason in clamp_reasons:
+                self.contribute_clamp_reason_counts[reason] = (
+                    int(self.contribute_clamp_reason_counts.get(reason, 0)) + 1
+                )
+
+            event = {
+                "t": int(obs.t),
+                "before": float(raw_contribute),
+                "after": float(contribute),
+                "reasons": list(clamp_reasons),
+                "limits": {
+                    "min": 0.0,
+                    "max_contribute": float(max_contribute),
+                    "wealth": float(wealth),
+                },
+            }
+            self.contribute_clamp_events.append(event)
+            if len(self.contribute_clamp_events) > 50:
+                self.contribute_clamp_events = self.contribute_clamp_events[-50:]
 
         return OpenResourcesAction(harvest=harvest, contribute=contribute)

--- a/llm_social_simulation/models/policies/llm_open_resources.py
+++ b/llm_social_simulation/models/policies/llm_open_resources.py
@@ -1,13 +1,5 @@
 from __future__ import annotations
 
-import json
-from dataclasses import dataclass, field
-from typing import Any
-
-from llm_social_simulation.models.client import LLMClient
-from llm_social_simulation.models.types import LLMParseError, LLMRequest
-from llm_social_simulation.simulation.gameworld import OpenResourcesAction, OpenResourcesObservation
-
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -26,19 +18,6 @@ class LLMOpenResourcesPolicyConfig:
     model: str
     run_id: str
     temperature: float = 0.0
-    max_tokens: int = 160
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-
-class LLMOpenResourcesPolicy:
-    """LLM-backed policy for Open Resources decisions with strict parsing."""
-
-    def __init__(self, *, agent_id: int, client: LLMClient, config: LLMOpenResourcesPolicyConfig):
-        self.agent_id = agent_id
-        self.client = client
-        self.config = config
-
-    def decide(self, obs: OpenResourcesObservation) -> OpenResourcesAction:
     max_tokens: int = 220
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -58,36 +37,15 @@ class LLMOpenResourcesPolicy(OpenResourcesPolicy):
         self.client = client
         self.config = config
         self.memory_store = memory_store or MemoryWindowStore()
+        self.parse_retry_count = 0
+        self.filled_id_count = 0
 
     def decide(self, obs: OpenResourcesObservation) -> OpenResourcesAction:
-        # --- validate observation belongs to this policy instance ---
         if obs.self_id != self.agent_id:
             raise ValueError(
                 f"Observation self_id {obs.self_id} does not match policy agent_id {self.agent_id}"
             )
 
-        request = LLMRequest(
-            model=self.config.model,
-            messages=(
-                {"role": "system", "content": "Return strict JSON decision for Open Resources."},
-                {
-                    "role": "user",
-                    "content": json.dumps(
-                        {
-                            "self_id": obs.self_id,
-                            "t": obs.t,
-                            "R": obs.R,
-                            "P": obs.P,
-                            "self_wealth": obs.self_wealth,
-                            "known_agents": list(obs.known_agents),
-                        },
-                        sort_keys=True,
-                    ),
-                },
-            ),
-            temperature=float(self.config.temperature),
-            max_tokens=int(self.config.max_tokens),
-        # --- build prompt messages from observation + recent memory ---
         memory_window = self.memory_store.get_window(self.agent_id)
         messages = build_open_resources_messages(
             obs,
@@ -95,7 +53,6 @@ class LLMOpenResourcesPolicy(OpenResourcesPolicy):
             run_id=self.config.run_id,
         )
 
-        # --- create provider-agnostic request envelope ---
         request = LLMRequest(
             model=self.config.model,
             messages=messages,
@@ -109,40 +66,9 @@ class LLMOpenResourcesPolicy(OpenResourcesPolicy):
                 "t": obs.t,
             },
         )
-        response = self.client.generate(request)
-        try:
-            raw = json.loads(response.content)
-        except json.JSONDecodeError as exc:
-            raise LLMParseError("LLM response is not valid JSON") from exc
 
-        if not isinstance(raw, dict):
-            raise LLMParseError("LLM response must be a JSON object")
-
-        self_id = raw.get("self_id", raw.get("agent_id"))
-        t = raw.get("t")
-        if self_id != self.agent_id:
-            raise LLMParseError(f"self_id mismatch: expected {self.agent_id}, got {self_id}")
-        if t != obs.t:
-            raise LLMParseError(f"t mismatch: expected {obs.t}, got {t}")
-
-        action = raw.get("action")
-        if not isinstance(action, dict):
-            raise LLMParseError("missing action object")
-        if "harvest" not in action or "contribute" not in action:
-            raise LLMParseError("action must include harvest and contribute")
-
-        try:
-            harvest = float(action["harvest"])
-            contribute = float(action["contribute"])
-        except (TypeError, ValueError) as exc:
-            raise LLMParseError("harvest and contribute must be numeric") from exc
-
-        return OpenResourcesAction(harvest=harvest, contribute=contribute)
-
-        # --- call model client (network/provider boundary) ---
         response = self.client.generate(request)
 
-        # --- parse and strictly validate model output (retry once on malformed output) ---
         try:
             parsed = parse_open_resources_decision(
                 response.content,
@@ -150,6 +76,7 @@ class LLMOpenResourcesPolicy(OpenResourcesPolicy):
                 expected_t=obs.t,
             )
         except LLMParseError:
+            self.parse_retry_count += 1
             retry_messages = messages + (
                 {
                     "role": "user",
@@ -180,7 +107,9 @@ class LLMOpenResourcesPolicy(OpenResourcesPolicy):
                 expected_t=obs.t,
             )
 
-        # --- persist this decision into per-agent memory ---
+        if parsed.id_filled:
+            self.filled_id_count += 1
+
         outcome = obs.info.get("last_step_self")
         outcome_payload = dict(outcome) if isinstance(outcome, dict) else None
         self.memory_store.append(
@@ -199,5 +128,4 @@ class LLMOpenResourcesPolicy(OpenResourcesPolicy):
             ),
         )
 
-        # --- return action used by OpenResourcesGameWorld.apply_actions ---
         return parsed.action

--- a/llm_social_simulation/models/policies/llm_open_resources.py
+++ b/llm_social_simulation/models/policies/llm_open_resources.py
@@ -37,8 +37,36 @@ class LLMOpenResourcesPolicy(OpenResourcesPolicy):
         self.client = client
         self.config = config
         self.memory_store = memory_store or MemoryWindowStore()
+        self.llm_call_total = 0
+        self.llm_response_empty_total = 0
+        self.parsed_action_zero_total = 0
+        self.llm_skipped_total = 0
         self.parse_retry_count = 0
         self.filled_id_count = 0
+        self.last_raw_output: str | None = None
+        self.last_provider: str | None = None
+
+    def _record_response(self, content: str, raw: Any) -> None:
+        self.llm_call_total += 1
+        text = content if isinstance(content, str) else str(content)
+        self.last_raw_output = text[:200]
+        if text.strip() == "":
+            self.llm_response_empty_total += 1
+
+        provider: str | None = None
+        if isinstance(raw, dict):
+            raw_provider = raw.get("provider")
+            if isinstance(raw_provider, dict):
+                for key in ("name", "provider", "slug"):
+                    value = raw_provider.get(key)
+                    if isinstance(value, str) and value.strip():
+                        provider = value
+                        break
+                if provider is None:
+                    provider = str(raw_provider)
+            elif isinstance(raw_provider, str):
+                provider = raw_provider
+        self.last_provider = provider
 
     def decide(self, obs: OpenResourcesObservation) -> OpenResourcesAction:
         if obs.self_id != self.agent_id:
@@ -68,6 +96,7 @@ class LLMOpenResourcesPolicy(OpenResourcesPolicy):
         )
 
         response = self.client.generate(request)
+        self._record_response(response.content, response.raw)
 
         try:
             parsed = parse_open_resources_decision(
@@ -101,6 +130,7 @@ class LLMOpenResourcesPolicy(OpenResourcesPolicy):
                 },
             )
             retry_response = self.client.generate(retry_request)
+            self._record_response(retry_response.content, retry_response.raw)
             parsed = parse_open_resources_decision(
                 retry_response.content,
                 expected_agent_id=self.agent_id,
@@ -109,6 +139,8 @@ class LLMOpenResourcesPolicy(OpenResourcesPolicy):
 
         if parsed.id_filled:
             self.filled_id_count += 1
+        if parsed.action.harvest == 0.0 and parsed.action.contribute == 0.0:
+            self.parsed_action_zero_total += 1
 
         outcome = obs.info.get("last_step_self")
         outcome_payload = dict(outcome) if isinstance(outcome, dict) else None

--- a/llm_social_simulation/models/policies/test_guardrails.py
+++ b/llm_social_simulation/models/policies/test_guardrails.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from llm_social_simulation.models.policies.guardrails import GuardrailsPolicy
+from llm_social_simulation.simulation.gameworld import OpenResourcesAction, OpenResourcesObservation
+
+
+class _StubPolicy:
+    def __init__(self, agent_id: int, contribute: float):
+        self.agent_id = agent_id
+        self._contribute = contribute
+
+    def decide(self, obs: OpenResourcesObservation) -> OpenResourcesAction:
+        del obs
+        return OpenResourcesAction(harvest=1.0, contribute=self._contribute)
+
+
+def _obs() -> OpenResourcesObservation:
+    return OpenResourcesObservation(
+        self_id=0,
+        t=0,
+        R=50.0,
+        P=0.0,
+        self_wealth=10.0,
+        known_agents=[0, 1],
+        info={},
+    )
+
+
+def test_guardrails_contribute_clamp_bounds() -> None:
+    obs = _obs()
+
+    neg = GuardrailsPolicy(
+        agent_id=0,
+        inner=_StubPolicy(agent_id=0, contribute=-5.0),
+        max_harvest_per_step=10.0,
+        contrib_max_frac=0.2,
+    )
+    high = GuardrailsPolicy(
+        agent_id=0,
+        inner=_StubPolicy(agent_id=0, contribute=99.0),
+        max_harvest_per_step=10.0,
+        contrib_max_frac=0.2,
+    )
+
+    neg_act = neg.decide(obs)
+    high_act = high.decide(obs)
+
+    assert 0.0 <= neg_act.contribute <= 2.0
+    assert 0.0 <= high_act.contribute <= 2.0
+    assert neg_act.contribute == 0.0
+    assert high_act.contribute == 2.0
+    assert neg.contribute_clamp_count == 1
+    assert high.contribute_clamp_count == 1
+    assert neg.contribute_clamp_reason_counts["negative"] >= 1
+    assert high.contribute_clamp_reason_counts["above_max_contribute"] >= 1

--- a/llm_social_simulation/models/policies/test_llm_policy_diagnostics.py
+++ b/llm_social_simulation/models/policies/test_llm_policy_diagnostics.py
@@ -1,0 +1,94 @@
+import json
+
+from llm_social_simulation.models.client import LLMClient
+from llm_social_simulation.models.policies.llm_open_resources import (
+    LLMOpenResourcesPolicy,
+    LLMOpenResourcesPolicyConfig,
+)
+from llm_social_simulation.models.types import LLMRequest, LLMResponse
+from llm_social_simulation.simulation.gameworld import OpenResourcesConfig, OpenResourcesGameWorld
+
+
+class ZeroActionClient(LLMClient):
+    def generate(self, request: LLMRequest) -> LLMResponse:
+        content = json.dumps(
+            {
+                "required": True,
+                "self_id": int(request.metadata["agent_id"]),
+                "t": int(request.metadata["t"]),
+                "action": {"harvest": 0.0, "contribute": 0.0},
+            }
+        )
+        return LLMResponse(
+            content=content,
+            model=f"mock:{request.model}",
+            request_hash=request.stable_hash(),
+            latency_ms=0.0,
+            usage=None,
+            raw={"provider": {"name": "mock-provider"}},
+        )
+
+
+class EmptyThenValidClient(LLMClient):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def generate(self, request: LLMRequest) -> LLMResponse:
+        self.calls += 1
+        if self.calls == 1:
+            content = ""
+        else:
+            content = json.dumps(
+                {
+                    "required": True,
+                    "self_id": int(request.metadata["agent_id"]),
+                    "t": int(request.metadata["t"]),
+                    "action": {"harvest": 1.0, "contribute": 0.0},
+                }
+            )
+        return LLMResponse(
+            content=content,
+            model=f"mock:{request.model}",
+            request_hash=request.stable_hash(),
+            latency_ms=0.0,
+            usage=None,
+            raw={"provider": {"name": "mock-provider"}},
+        )
+
+
+def _obs():
+    world = OpenResourcesGameWorld(OpenResourcesConfig(agent_ids=(0,), initial_resource=10.0))
+    return world.get_observation(0)
+
+
+def test_llm_policy_diagnostics_zero_action_counted() -> None:
+    policy = LLMOpenResourcesPolicy(
+        agent_id=0,
+        client=ZeroActionClient(),
+        config=LLMOpenResourcesPolicyConfig(model="unit-model", run_id="diag-zero"),
+    )
+
+    action = policy.decide(_obs())
+    assert action.harvest == 0.0
+    assert action.contribute == 0.0
+    assert policy.llm_call_total == 1
+    assert policy.llm_response_empty_total == 0
+    assert policy.parsed_action_zero_total == 1
+    assert policy.last_raw_output is not None
+    assert policy.last_provider == "mock-provider"
+
+
+def test_llm_policy_diagnostics_empty_response_counted_and_retried() -> None:
+    client = EmptyThenValidClient()
+    policy = LLMOpenResourcesPolicy(
+        agent_id=0,
+        client=client,
+        config=LLMOpenResourcesPolicyConfig(model="unit-model", run_id="diag-empty"),
+    )
+
+    action = policy.decide(_obs())
+    assert action.harvest == 1.0
+    assert action.contribute == 0.0
+    assert policy.llm_call_total == 2
+    assert policy.llm_response_empty_total == 1
+    assert policy.parse_retry_count == 1

--- a/llm_social_simulation/models/prompt_builder.py
+++ b/llm_social_simulation/models/prompt_builder.py
@@ -19,6 +19,9 @@ def _system_prompt() -> str:
         "Explore with small non-zero moves when safe "
         "(for example harvest 0.5-2.0 or contribute 0.1-1.0). "
         "Respond with JSON only (no markdown or code fences). "
+        "Hard constraints: harvest >= 0 and contribute >= 0. "
+        "Contribute must not exceed your current self_wealth. "
+        "Prefer contribute <= 20% of self_wealth unless there is a strong reason. "
         "Required output schema: "
         '{"required":true,"self_id":<int>,"t":<int>,'
         '"action":{"harvest":<float>=0,"contribute":<float>=0},'
@@ -42,7 +45,7 @@ def build_open_resources_messages(
         "decision_task": (
             "Return action.harvest and action.contribute for this round. "
             "Prefer informative, non-degenerate actions over always "
-            "returning zeros when risk is low."
+            "returning zeros when risk is low. Keep contribute within the provided bounds."
         ),
         "observation": {
             "self_id": obs.self_id,
@@ -57,6 +60,9 @@ def build_open_resources_messages(
         "constraints": {
             "harvest_min": 0.0,
             "contribute_min": 0.0,
+            "contribute_max_by_wealth": float(obs.self_wealth),
+            "recommended_contribute_cap_frac": 0.2,
+            "recommended_contribute_cap": 0.2 * float(obs.self_wealth),
             "required_must_be_true": True,
         },
     }

--- a/llm_social_simulation/models/schema.py
+++ b/llm_social_simulation/models/schema.py
@@ -11,6 +11,28 @@ from .types import LLMParseError
 TModel = TypeVar("TModel", bound=BaseModel)
 
 
+def _force_no_additional_props(node: object) -> None:
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            node.setdefault("additionalProperties", False)
+            props = node.get("properties")
+            if isinstance(props, dict):
+                for child in props.values():
+                    _force_no_additional_props(child)
+
+        for key in ("items", "anyOf", "oneOf", "allOf"):
+            if key in node:
+                _force_no_additional_props(node[key])
+
+        for value in node.values():
+            _force_no_additional_props(value)
+        return
+
+    if isinstance(node, list):
+        for child in node:
+            _force_no_additional_props(child)
+
+
 def _strip_markdown_fences(content: str) -> str:
     text = content.strip()
     if not text.startswith("```"):
@@ -58,11 +80,13 @@ def strict_json_parse(content: str, schema: type[TModel]) -> TModel:
 
 def response_format_for_schema(schema: type[BaseModel]) -> dict[str, object]:
     """Provider-ready json-schema response format."""
+    json_schema = schema.model_json_schema()
+    _force_no_additional_props(json_schema)
     return {
         "type": "json_schema",
         "json_schema": {
             "name": schema.__name__,
-            "schema": schema.model_json_schema(),
+            "schema": json_schema,
             "strict": True,
         },
     }

--- a/llm_social_simulation/models/schema.py
+++ b/llm_social_simulation/models/schema.py
@@ -17,6 +17,7 @@ def _force_no_additional_props(node: object) -> None:
             node.setdefault("additionalProperties", False)
             props = node.get("properties")
             if isinstance(props, dict):
+                node["required"] = list(props.keys())
                 for child in props.values():
                     _force_no_additional_props(child)
 

--- a/llm_social_simulation/models/tests/test_parser_open_resources.py
+++ b/llm_social_simulation/models/tests/test_parser_open_resources.py
@@ -39,10 +39,17 @@ def test_parse_open_resources_tolerates_missing_id_and_fills_expected() -> None:
     assert parsed.id_source == "fallback"
 
 
-def test_parse_open_resources_requires_true_required_field() -> None:
+def test_parse_open_resources_rejects_required_false() -> None:
     content = '{"required":false,"self_id":3,"t":12,"action":{"harvest":1.1,"contribute":0.3}}'
     with pytest.raises(LLMParseError):
         parse_open_resources_decision(content, expected_agent_id=3, expected_t=12)
+
+
+def test_parse_open_resources_tolerates_missing_required_field() -> None:
+    content = '{"self_id":3,"t":12,"action":{"harvest":1.1,"contribute":0.3}}'
+    parsed = parse_open_resources_decision(content, expected_agent_id=3, expected_t=12)
+    assert parsed.action.harvest == pytest.approx(1.1)
+    assert parsed.action.contribute == pytest.approx(0.3)
 
 
 def test_parse_open_resources_rejects_id_or_round_mismatch() -> None:

--- a/llm_social_simulation/models/tests/test_parser_open_resources.py
+++ b/llm_social_simulation/models/tests/test_parser_open_resources.py
@@ -14,6 +14,29 @@ def test_parse_open_resources_decision_success() -> None:
     assert parsed.action.harvest == pytest.approx(1.1)
     assert parsed.action.contribute == pytest.approx(0.3)
     assert parsed.reason == "ok"
+    assert parsed.id_filled is False
+    assert parsed.id_source == "self_id"
+
+
+def test_parse_open_resources_accepts_agent_id_alias() -> None:
+    content = (
+        '{"required":true,"agent_id":3,"t":12,'
+        '"action":{"harvest":1.1,"contribute":0.3},"reason":"ok"}'
+    )
+    parsed = parse_open_resources_decision(content, expected_agent_id=3, expected_t=12)
+    assert parsed.action.harvest == pytest.approx(1.1)
+    assert parsed.action.contribute == pytest.approx(0.3)
+    assert parsed.id_filled is False
+    assert parsed.id_source == "agent_id"
+
+
+def test_parse_open_resources_tolerates_missing_id_and_fills_expected() -> None:
+    content = '{"required":true,"t":12,"action":{"harvest":1.1,"contribute":0.3}}'
+    parsed = parse_open_resources_decision(content, expected_agent_id=3, expected_t=12)
+    assert parsed.action.harvest == pytest.approx(1.1)
+    assert parsed.action.contribute == pytest.approx(0.3)
+    assert parsed.id_filled is True
+    assert parsed.id_source == "fallback"
 
 
 def test_parse_open_resources_requires_true_required_field() -> None:

--- a/llm_social_simulation/models/tests/test_prompt_builder.py
+++ b/llm_social_simulation/models/tests/test_prompt_builder.py
@@ -70,3 +70,13 @@ def test_prompt_builder_keeps_memory_in_chronological_order() -> None:
     messages = build_open_resources_messages(_obs(), memory, run_id="run-2")
     user_payload = json.loads(messages[1]["content"])
     assert [m["t"] for m in user_payload["memory_window"]] == [1, 2]
+
+
+def test_prompt_builder_mentions_contribute_bounds() -> None:
+    messages = build_open_resources_messages(_obs(), [], run_id="run-3")
+    system_prompt = messages[0]["content"]
+    user_payload = json.loads(messages[1]["content"])
+
+    assert "Contribute must not exceed your current self_wealth." in system_prompt
+    assert "contribute_max_by_wealth" in user_payload["constraints"]
+    assert "recommended_contribute_cap" in user_payload["constraints"]

--- a/llm_social_simulation/models/tests/test_schema.py
+++ b/llm_social_simulation/models/tests/test_schema.py
@@ -1,13 +1,23 @@
 import pytest
 from pydantic import BaseModel
 
-from llm_social_simulation.models.schema import strict_json_parse
+from llm_social_simulation.models.schema import response_format_for_schema, strict_json_parse
 from llm_social_simulation.models.types import LLMParseError
 
 
 class Decision(BaseModel):
     action: str
     confidence: float
+
+
+class NestedAction(BaseModel):
+    harvest: float
+    contribute: float
+
+
+class NestedDecision(BaseModel):
+    self_id: int
+    action: NestedAction
 
 
 def test_strict_json_parse_success() -> None:
@@ -37,3 +47,16 @@ def test_strict_json_parse_accepts_json_embedded_in_text() -> None:
     parsed = strict_json_parse(content, Decision)
     assert parsed.action == "D"
     assert parsed.confidence == pytest.approx(0.2)
+
+
+def test_response_format_for_schema_forces_additional_properties_false_recursively() -> None:
+    response_format = response_format_for_schema(NestedDecision)
+    schema = response_format["json_schema"]["schema"]  # type: ignore[index]
+    assert schema["additionalProperties"] is False  # type: ignore[index]
+
+    action_schema = schema["properties"]["action"]  # type: ignore[index]
+    if "$ref" in action_schema:
+        ref = action_schema["$ref"]  # type: ignore[index]
+        ref_name = str(ref).split("/")[-1]
+        action_schema = schema["$defs"][ref_name]  # type: ignore[index]
+    assert action_schema["additionalProperties"] is False  # type: ignore[index]

--- a/llm_social_simulation/models/tests/test_schema.py
+++ b/llm_social_simulation/models/tests/test_schema.py
@@ -20,6 +20,11 @@ class NestedDecision(BaseModel):
     action: NestedAction
 
 
+class OptionalDecision(BaseModel):
+    self_id: int | None = None
+    action: NestedAction
+
+
 def test_strict_json_parse_success() -> None:
     parsed = strict_json_parse('{"action":"C","confidence":0.5}', Decision)
     assert parsed.action == "C"
@@ -53,6 +58,7 @@ def test_response_format_for_schema_forces_additional_properties_false_recursive
     response_format = response_format_for_schema(NestedDecision)
     schema = response_format["json_schema"]["schema"]  # type: ignore[index]
     assert schema["additionalProperties"] is False  # type: ignore[index]
+    assert sorted(schema["required"]) == ["action", "self_id"]  # type: ignore[index]
 
     action_schema = schema["properties"]["action"]  # type: ignore[index]
     if "$ref" in action_schema:
@@ -60,3 +66,11 @@ def test_response_format_for_schema_forces_additional_properties_false_recursive
         ref_name = str(ref).split("/")[-1]
         action_schema = schema["$defs"][ref_name]  # type: ignore[index]
     assert action_schema["additionalProperties"] is False  # type: ignore[index]
+    assert sorted(action_schema["required"]) == ["contribute", "harvest"]  # type: ignore[index]
+
+
+def test_response_format_for_schema_marks_optional_fields_as_required_for_provider() -> None:
+    response_format = response_format_for_schema(OptionalDecision)
+    schema = response_format["json_schema"]["schema"]  # type: ignore[index]
+    # Provider requires this array to include every property key.
+    assert sorted(schema["required"]) == ["action", "self_id"]  # type: ignore[index]

--- a/llm_social_simulation/simulation/run_open_resources_baseline.py
+++ b/llm_social_simulation/simulation/run_open_resources_baseline.py
@@ -128,6 +128,86 @@ def _build_agents(
     raise ValueError(f"Unsupported agent_type: {agent_type}")
 
 
+def _collect_llm_diagnostics(agents: list[Any], llm_guardrails: bool) -> dict[str, Any]:
+    per_agent: dict[str, dict[str, Any]] = {}
+    for idx, agent in enumerate(agents):
+        # When guardrails are enabled, policy metrics live on wrapper.inner.
+        policy = getattr(agent, "inner", agent)
+        agent_id = str(getattr(policy, "agent_id", getattr(agent, "agent_id", idx)))
+
+        client = getattr(policy, "client", None)
+        client_mode = type(client).__name__ if client is not None else "unknown"
+
+        per_agent[agent_id] = {
+            "client_mode": client_mode,
+            "llm_call_total": int(getattr(policy, "llm_call_total", 0)),
+            "llm_response_empty_total": int(getattr(policy, "llm_response_empty_total", 0)),
+            "parsed_action_zero_total": int(getattr(policy, "parsed_action_zero_total", 0)),
+            "llm_skipped_total": int(getattr(policy, "llm_skipped_total", 0)),
+            "parse_retry_count": int(getattr(policy, "parse_retry_count", 0)),
+            "filled_id_count": int(getattr(policy, "filled_id_count", 0)),
+            "fail_closed_count": int(getattr(agent, "fail_closed_count", 0)),
+            "harvest_nan_count": int(getattr(agent, "harvest_nan_count", 0)),
+            "contribute_nan_count": int(getattr(agent, "contribute_nan_count", 0)),
+            "harvest_clamp_count": int(getattr(agent, "harvest_clamp_count", 0)),
+            "contribute_clamp_count": int(getattr(agent, "contribute_clamp_count", 0)),
+            "contribute_clamp_reason_counts": dict(
+                getattr(agent, "contribute_clamp_reason_counts", {})
+            ),
+            "last_contribute_clamp_event": (
+                getattr(agent, "contribute_clamp_events", [])[-1]
+                if getattr(agent, "contribute_clamp_events", [])
+                else None
+            ),
+            "last_raw_output": getattr(policy, "last_raw_output", None),
+            "last_provider": getattr(policy, "last_provider", None),
+            "last_error": getattr(agent, "last_error", None),
+        }
+
+    entries = list(per_agent.values())
+    return {
+        "guardrails_enabled": bool(llm_guardrails),
+        "client_modes": sorted({str(entry["client_mode"]) for entry in entries}),
+        "llm_call_total": int(sum(int(entry["llm_call_total"]) for entry in entries)),
+        "llm_response_empty_total": int(
+            sum(int(entry["llm_response_empty_total"]) for entry in entries)
+        ),
+        "parsed_action_zero_total": int(
+            sum(int(entry["parsed_action_zero_total"]) for entry in entries)
+        ),
+        "llm_skipped_total": int(sum(int(entry["llm_skipped_total"]) for entry in entries)),
+        "parse_retry_total": int(sum(int(entry["parse_retry_count"]) for entry in entries)),
+        "id_filled_total": int(sum(int(entry["filled_id_count"]) for entry in entries)),
+        "guardrails_fail_closed_total": int(
+            sum(int(entry["fail_closed_count"]) for entry in entries)
+        ),
+        "guardrails_harvest_clamp_total": int(
+            sum(int(entry["harvest_clamp_count"]) for entry in entries)
+        ),
+        "guardrails_contribute_clamp_total": int(
+            sum(int(entry["contribute_clamp_count"]) for entry in entries)
+        ),
+        "guardrails_contribute_clamp_reason_totals": {
+            "nan": int(
+                sum(int(entry["contribute_clamp_reason_counts"].get("nan", 0)) for entry in entries)
+            ),
+            "negative": int(
+                sum(
+                    int(entry["contribute_clamp_reason_counts"].get("negative", 0))
+                    for entry in entries
+                )
+            ),
+            "above_max_contribute": int(
+                sum(
+                    int(entry["contribute_clamp_reason_counts"].get("above_max_contribute", 0))
+                    for entry in entries
+                )
+            ),
+        },
+        "per_agent": per_agent,
+    }
+
+
 def run_baseline_experiment(
     *,
     agent_type: str,
@@ -172,6 +252,10 @@ def run_baseline_experiment(
     final_p = float(final_tick.P_after) if final_tick is not None else float(config.initial_pool)
 
     ct = collapse_time(ticks)
+    llm_diagnostics: dict[str, Any] | None = None
+    if agent_type == "llm":
+        llm_diagnostics = _collect_llm_diagnostics(agents=agents, llm_guardrails=llm_guardrails)
+
     summary = {
         "collapsed": ct is not None,
         "collapse_time": ct,
@@ -188,6 +272,7 @@ def run_baseline_experiment(
         },
         "R_series_head": resource_series(ticks)[:10],
         "P_series_head": pool_series(ticks)[:10],
+        "llm_diagnostics": llm_diagnostics,
     }
     return ticks, summary
 

--- a/llm_social_simulation/simulation/run_open_resources_phase_map.py
+++ b/llm_social_simulation/simulation/run_open_resources_phase_map.py
@@ -227,7 +227,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action=argparse.BooleanOptionalAction,
         default=True,
     )
-    parser.add_argument("--max-workers", type=int, default=1)
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=1,
+        help="Reserved for future parallel execution. Current implementation runs sequentially.",
+    )
     return parser.parse_args(argv)
 
 

--- a/llm_social_simulation/simulation/run_open_resources_sweep.py
+++ b/llm_social_simulation/simulation/run_open_resources_sweep.py
@@ -419,7 +419,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action=argparse.BooleanOptionalAction,
         default=True,
     )
-    parser.add_argument("--max-workers", type=int, default=1)
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=1,
+        help="Reserved for future parallel execution. Current implementation runs sequentially.",
+    )
     return parser.parse_args(argv)
 
 

--- a/llm_social_simulation/simulation/test_engine_dummy.py
+++ b/llm_social_simulation/simulation/test_engine_dummy.py
@@ -21,10 +21,8 @@ class DummyAgent:
         return {}
 
 
-# ---- Run test ----
-
-if __name__ == "__main__":
+def test_engine_runs_dummy_world() -> None:
     engine = SimulationEngine(DummyGameworld(), [DummyAgent(0), DummyAgent(1)])
-
     history = engine.run(3)
-    print("History:", history)
+    assert len(history) == 3
+    assert all("actions" in tick for tick in history)

--- a/llm_social_simulation/simulation/test_open_resources_llm_diagnostics.py
+++ b/llm_social_simulation/simulation/test_open_resources_llm_diagnostics.py
@@ -1,0 +1,50 @@
+from llm_social_simulation.simulation.run_open_resources_baseline import _collect_llm_diagnostics
+
+
+class _DummyPolicy:
+    def __init__(self, agent_id: int, llm_call_total: int, parsed_action_zero_total: int):
+        self.agent_id = agent_id
+        self.llm_call_total = llm_call_total
+        self.llm_response_empty_total = 0
+        self.parsed_action_zero_total = parsed_action_zero_total
+        self.llm_skipped_total = 0
+        self.parse_retry_count = 0
+        self.filled_id_count = 0
+        self.last_raw_output = '{"action":{"harvest":1.0,"contribute":0.0}}'
+        self.last_provider = "mock-provider"
+        self.client = object()
+
+
+class _DummyGuardrails:
+    def __init__(self, agent_id: int, inner):
+        self.agent_id = agent_id
+        self.inner = inner
+        self.fail_closed_count = 0
+        self.harvest_nan_count = 0
+        self.contribute_nan_count = 0
+        self.harvest_clamp_count = 0
+        self.contribute_clamp_count = 0
+        self.contribute_clamp_reason_counts = {}
+        self.contribute_clamp_events = []
+        self.last_error = None
+
+
+def test_collect_llm_diagnostics_reads_inner_policy_metrics_when_guardrails_enabled() -> None:
+    wrapped_agents = [
+        _DummyGuardrails(
+            agent_id=0,
+            inner=_DummyPolicy(0, llm_call_total=5, parsed_action_zero_total=1),
+        ),
+        _DummyGuardrails(
+            agent_id=1,
+            inner=_DummyPolicy(1, llm_call_total=5, parsed_action_zero_total=0),
+        ),
+    ]
+
+    diag = _collect_llm_diagnostics(wrapped_agents, llm_guardrails=True)
+
+    assert diag["llm_call_total"] == 10
+    assert diag["parsed_action_zero_total"] == 1
+    assert diag["llm_skipped_total"] == 0
+    assert diag["per_agent"]["0"]["llm_call_total"] == 5
+    assert diag["per_agent"]["1"]["llm_call_total"] == 5


### PR DESCRIPTION
- This PR improves reliability and debuggability of the LLM agent path in Open Resources simulations.
- It fixes schema/provider compatibility issues, hardens parsing and guardrails behavior, and adds diagnostics to explain “static trajectory” runs (e.g., all-zero actions).
- I do this because I observed intermittent runs where --agent-type llm --llm-guardrails produced no state change (R/P/wealth static).
- Root causes included: provider-side schema strictness (response_format expectations), insufficient observability in the LLM call path, diagnostics reading wrapper-level stats instead of inner LLM policy stats when guardrails are enabled.
